### PR TITLE
feat: add custom domain support for CloudFront distributions

### DIFF
--- a/source/constructs/lib/back-end/api-gateway-architecture.ts
+++ b/source/constructs/lib/back-end/api-gateway-architecture.ts
@@ -135,6 +135,26 @@ export class ApiGatewayArchitecture {
         { Enabled: false },
       ],
     });
+    cfnDistribution.addPropertyOverride("DistributionConfig.Aliases", {
+      "Fn::If": [
+        props.conditions.useCustomDomainCondition.logicalId,
+        [props.customDomainName],
+        { Ref: "AWS::NoValue" },
+      ],
+    });
+    cfnDistribution.addPropertyOverride("DistributionConfig.ViewerCertificate", {
+      "Fn::If": [
+        props.conditions.useCustomDomainCondition.logicalId,
+        {
+          AcmCertificateArn: props.certificateArn,
+          SslSupportMethod: "sni-only",
+          MinimumProtocolVersion: "TLSv1.2_2021",
+        },
+        {
+          CloudFrontDefaultCertificate: true,
+        },
+      ],
+    });
     Aspects.of(cfnDistribution).add(
       new ConditionAspect(
         new CfnCondition(scope, "DeployAPIGDistribution", {

--- a/source/constructs/lib/back-end/s3-object-lambda-architecture.ts
+++ b/source/constructs/lib/back-end/s3-object-lambda-architecture.ts
@@ -242,6 +242,26 @@ export class S3ObjectLambdaArchitecture {
         { Enabled: false },
       ],
     });
+    cfnDistribution.addPropertyOverride("DistributionConfig.Aliases", {
+      "Fn::If": [
+        props.conditions.useCustomDomainCondition.logicalId,
+        [props.customDomainName],
+        { Ref: "AWS::NoValue" },
+      ],
+    });
+    cfnDistribution.addPropertyOverride("DistributionConfig.ViewerCertificate", {
+      "Fn::If": [
+        props.conditions.useCustomDomainCondition.logicalId,
+        {
+          AcmCertificateArn: props.certificateArn,
+          SslSupportMethod: "sni-only",
+          MinimumProtocolVersion: "TLSv1.2_2021",
+        },
+        {
+          CloudFrontDefaultCertificate: true,
+        },
+      ],
+    });
     scope.olDomainName = Fn.conditionIf(
       props.conditions.useExistingCloudFrontDistributionCondition.logicalId,
       props.existingDistribution.distributionDomainName,

--- a/source/constructs/lib/common-resources/common-resources-construct.ts
+++ b/source/constructs/lib/common-resources/common-resources-construct.ts
@@ -26,6 +26,7 @@ export interface Conditions {
   readonly disableS3ObjectLambdaCondition: CfnCondition;
   readonly isLogRetentionPeriodInfinite: CfnCondition;
   readonly useExistingCloudFrontDistributionCondition: CfnCondition;
+  readonly useCustomDomainCondition: CfnCondition;
 }
 
 /**
@@ -70,6 +71,9 @@ export class CommonResources extends Construct {
       }),
       useExistingCloudFrontDistributionCondition: new CfnCondition(this, "UseExistingCloudFrontDistributionCondition", {
         expression: Fn.conditionEquals(props.useExistingCloudFrontDistribution, "Yes"),
+      }),
+      useCustomDomainCondition: new CfnCondition(this, "UseCustomDomainCondition", {
+        expression: Fn.conditionNot(Fn.conditionEquals(props.customDomainName, "")),
       }),
     };
 

--- a/source/constructs/lib/serverless-image-stack.ts
+++ b/source/constructs/lib/serverless-image-stack.ts
@@ -183,6 +183,32 @@ export class ServerlessImageHandlerStack extends Stack {
     console.warn("📋 Default value is 'No' - recommended for all new deployments");
     console.warn("=".repeat(80) + "\n");
 
+    const customDomainNameParameter = new CfnParameter(this, "CustomDomainNameParameter", {
+      type: "String",
+      description:
+        "Optional custom domain name (e.g. images.example.com) to use as an alternate domain name (CNAME) for the CloudFront distribution. Leave empty to use the default CloudFront domain. When set, CertificateArnParameter must also be provided.",
+      default: "",
+    });
+
+    const certificateArnParameter = new CfnParameter(this, "CertificateArnParameter", {
+      type: "String",
+      description:
+        "The ARN of an ACM certificate in us-east-1 for the custom domain name. Required when CustomDomainNameParameter is set.",
+      default: "",
+      allowedPattern: "^$|^arn:aws:acm:us-east-1:[0-9]{12}:certificate/[a-f0-9-]+$",
+    });
+
+    new CfnRule(this, "CustomDomainCertificateRequiredRule", {
+      ruleCondition: Fn.conditionNot(Fn.conditionEquals(customDomainNameParameter.valueAsString, "")),
+      assertions: [
+        {
+          assert: Fn.conditionNot(Fn.conditionEquals(certificateArnParameter.valueAsString, "")),
+          assertDescription:
+            "If 'CustomDomainName' is set, 'CertificateArn' must be provided.",
+        },
+      ],
+    });
+
     const useExistingCloudFrontDistribution = new CfnParameter(this, "UseExistingCloudFrontDistributionParameter", {
       type: "String",
       description:
@@ -250,6 +276,8 @@ export class ServerlessImageHandlerStack extends Stack {
       enableS3ObjectLambda: enableS3ObjectLambdaParameter.valueAsString,
       useExistingCloudFrontDistribution: useExistingCloudFrontDistribution.valueAsString as YesNo,
       existingCloudFrontDistributionId: existingCloudFrontDistributionId.valueAsString,
+      customDomainName: customDomainNameParameter.valueAsString,
+      certificateArn: certificateArnParameter.valueAsString,
     };
 
     const commonResources = new CommonResources(this, "CommonResources", {
@@ -377,6 +405,13 @@ export class ServerlessImageHandlerStack extends Stack {
             Parameters: [autoWebPParameter.logicalId],
           },
           {
+            Label: { default: "Custom Domain" },
+            Parameters: [
+              customDomainNameParameter.logicalId,
+              certificateArnParameter.logicalId,
+            ],
+          },
+          {
             Label: { default: "CloudFront" },
             Parameters: [
               originShieldRegionParameter.logicalId,
@@ -425,6 +460,12 @@ export class ServerlessImageHandlerStack extends Stack {
           },
           [existingCloudFrontDistributionId.logicalId]: {
             default: "Existing CloudFront Distribution Id",
+          },
+          [customDomainNameParameter.logicalId]: {
+            default: "Custom Domain Name",
+          },
+          [certificateArnParameter.logicalId]: {
+            default: "ACM Certificate ARN",
           },
         },
       },

--- a/source/constructs/lib/types.ts
+++ b/source/constructs/lib/types.ts
@@ -20,4 +20,6 @@ export interface SolutionConstructProps {
   readonly enableS3ObjectLambda: string;
   readonly useExistingCloudFrontDistribution: YesNo;
   readonly existingCloudFrontDistributionId: string;
+  readonly customDomainName: string;
+  readonly certificateArn: string;
 }

--- a/source/constructs/test/__snapshots__/constructs.test.ts.snap
+++ b/source/constructs/test/__snapshots__/constructs.test.ts.snap
@@ -139,6 +139,18 @@ exports[`ServerlessImageHandlerStack Dynamic Image Transformation for Amazon Clo
         "Infinite",
       ],
     },
+    "CommonResourcesUseCustomDomainCondition430509C5": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "CustomDomainNameParameter",
+            },
+            "",
+          ],
+        },
+      ],
+    },
     "CommonResourcesUseExistingCloudFrontDistributionConditionEBC48184": {
       "Fn::Equals": [
         {
@@ -257,6 +269,15 @@ exports[`ServerlessImageHandlerStack Dynamic Image Transformation for Amazon Clo
         },
         {
           "Label": {
+            "default": "Custom Domain",
+          },
+          "Parameters": [
+            "CustomDomainNameParameter",
+            "CertificateArnParameter",
+          ],
+        },
+        {
+          "Label": {
             "default": "CloudFront",
           },
           "Parameters": [
@@ -271,6 +292,9 @@ exports[`ServerlessImageHandlerStack Dynamic Image Transformation for Amazon Clo
         "AutoWebPParameter": {
           "default": "AutoWebP",
         },
+        "CertificateArnParameter": {
+          "default": "ACM Certificate ARN",
+        },
         "CloudFrontPriceClassParameter": {
           "default": "CloudFront PriceClass",
         },
@@ -279,6 +303,9 @@ exports[`ServerlessImageHandlerStack Dynamic Image Transformation for Amazon Clo
         },
         "CorsOriginParameter": {
           "default": "CORS Origin",
+        },
+        "CustomDomainNameParameter": {
+          "default": "Custom Domain Name",
         },
         "DeployDemoUIParameter": {
           "default": "Deploy Demo UI",
@@ -525,6 +552,12 @@ exports[`ServerlessImageHandlerStack Dynamic Image Transformation for Amazon Clo
       "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "CertificateArnParameter": {
+      "AllowedPattern": "^$|^arn:aws:acm:us-east-1:[0-9]{12}:certificate/[a-f0-9-]+$",
+      "Default": "",
+      "Description": "The ARN of an ACM certificate in us-east-1 for the custom domain name. Required when CustomDomainNameParameter is set.",
+      "Type": "String",
+    },
     "CloudFrontPriceClassParameter": {
       "AllowedValues": [
         "PriceClass_All",
@@ -547,6 +580,11 @@ exports[`ServerlessImageHandlerStack Dynamic Image Transformation for Amazon Clo
     "CorsOriginParameter": {
       "Default": "*",
       "Description": "If you selected 'Yes' above, please specify an origin value here. A wildcard (*) value will support any origin. We recommend specifying an origin (i.e. https://example.domain) to restrict cross-site access to your API.",
+      "Type": "String",
+    },
+    "CustomDomainNameParameter": {
+      "Default": "",
+      "Description": "Optional custom domain name (e.g. images.example.com) to use as an alternate domain name (CNAME) for the CloudFront distribution. Leave empty to use the default CloudFront domain. When set, CertificateArnParameter must also be provided.",
       "Type": "String",
     },
     "DeployDemoUIParameter": {
@@ -962,6 +1000,19 @@ function processQueryParams(querystring) {
       },
       "Properties": {
         "DistributionConfig": {
+          "Aliases": {
+            "Fn::If": [
+              "CommonResourcesUseCustomDomainCondition430509C5",
+              [
+                {
+                  "Ref": "CustomDomainNameParameter",
+                },
+              ],
+              {
+                "Ref": "AWS::NoValue",
+              },
+            ],
+          },
           "Comment": "Image Handler Distribution for Dynamic Image Transformation for Amazon CloudFront",
           "CustomErrorResponses": [
             {
@@ -1085,6 +1136,21 @@ function processQueryParams(querystring) {
           ],
           "PriceClass": {
             "Ref": "CloudFrontPriceClassParameter",
+          },
+          "ViewerCertificate": {
+            "Fn::If": [
+              "CommonResourcesUseCustomDomainCondition430509C5",
+              {
+                "AcmCertificateArn": {
+                  "Ref": "CertificateArnParameter",
+                },
+                "MinimumProtocolVersion": "TLSv1.2_2021",
+                "SslSupportMethod": "sni-only",
+              },
+              {
+                "CloudFrontDefaultCertificate": true,
+              },
+            ],
           },
         },
         "Tags": [
@@ -1619,6 +1685,19 @@ function processQueryParams(querystring) {
       },
       "Properties": {
         "DistributionConfig": {
+          "Aliases": {
+            "Fn::If": [
+              "CommonResourcesUseCustomDomainCondition430509C5",
+              [
+                {
+                  "Ref": "CustomDomainNameParameter",
+                },
+              ],
+              {
+                "Ref": "AWS::NoValue",
+              },
+            ],
+          },
           "Comment": "Image Handler Distribution for Dynamic Image Transformation for Amazon CloudFront",
           "CustomErrorResponses": [
             {
@@ -1755,6 +1834,21 @@ function processQueryParams(querystring) {
           ],
           "PriceClass": {
             "Ref": "CloudFrontPriceClassParameter",
+          },
+          "ViewerCertificate": {
+            "Fn::If": [
+              "CommonResourcesUseCustomDomainCondition430509C5",
+              {
+                "AcmCertificateArn": {
+                  "Ref": "CertificateArnParameter",
+                },
+                "MinimumProtocolVersion": "TLSv1.2_2021",
+                "SslSupportMethod": "sni-only",
+              },
+              {
+                "CloudFrontDefaultCertificate": true,
+              },
+            ],
           },
         },
         "Tags": [
@@ -4443,6 +4537,37 @@ function handler(event) {
           "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
         },
       ],
+    },
+    "CustomDomainCertificateRequiredRule": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Equals": [
+                  {
+                    "Ref": "CertificateArnParameter",
+                  },
+                  "",
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "If 'CustomDomainName' is set, 'CertificateArn' must be provided.",
+        },
+      ],
+      "RuleCondition": {
+        "Fn::Not": [
+          {
+            "Fn::Equals": [
+              {
+                "Ref": "CustomDomainNameParameter",
+              },
+              "",
+            ],
+          },
+        ],
+      },
     },
     "ExistingDistributionIdRequiredRule": {
       "Assertions": [


### PR DESCRIPTION
## Summary

Add `CustomDomainNameParameter` and `CertificateArnParameter` CloudFormation parameters to allow configuring a custom domain (alternate CNAME) on the image handler CloudFront distribution.

When both parameters are provided, the distribution is configured with the custom domain alias and an ACM certificate (TLSv1.2, SNI-only). When omitted, the default CloudFront domain is used — fully backward compatible.

## Changes

- **`source/constructs/lib/types.ts`** — Added `customDomainName` and `certificateArn` to `SolutionConstructProps`
- **`source/constructs/lib/common-resources/common-resources-construct.ts`** — Added `useCustomDomainCondition`
- **`source/constructs/lib/serverless-image-stack.ts`** — Added `CustomDomainNameParameter` and `CertificateArnParameter` with validation rule requiring both when custom domain is set
- **`source/constructs/lib/back-end/s3-object-lambda-architecture.ts`** — Conditionally set `Aliases` and `ViewerCertificate` on CloudFront distribution via CFN property overrides
- **`source/constructs/lib/back-end/api-gateway-architecture.ts`** — Same for API Gateway architecture

## Testing

- `npx tsc --noEmit` passes (exit code 0)
- Both architectures (S3 Object Lambda and API Gateway) are updated
- Uses `Fn::If` with `UseCustomDomainCondition` so no-op when parameters are empty

## Related

[BAE-3409](https://linear.app/breakaway-data/issue/BAE-3409/setup-imagesbreakawaydatacom)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies CloudFront distribution configuration (aliases and viewer certificates), which can affect deployment/traffic if parameters are mis-set, though changes are guarded by CloudFormation conditions and default to no-op.
> 
> **Overview**
> Adds optional custom-domain support for the solution’s CloudFront distributions via new CloudFormation parameters `CustomDomainNameParameter` and `CertificateArnParameter`, including a template rule that requires a certificate ARN when a custom domain is provided.
> 
> Plumbs `customDomainName`/`certificateArn` through `SolutionConstructProps` and introduces `useCustomDomainCondition`, then conditionally overrides CloudFront `DistributionConfig.Aliases` and `DistributionConfig.ViewerCertificate` (TLSv1.2_2021, SNI-only) for both the API Gateway and S3 Object Lambda back-end architectures. Snapshot expectations are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3b46d33ee28ed5a7790a1dd6952664b5bd36663. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->