### PR TITLE
feat(cloudfront): attach Managed-CORS-with-preflight response headers policy

### DIFF
--- a/source/constructs/lib/back-end/api-gateway-architecture.ts
+++ b/source/constructs/lib/back-end/api-gateway-architecture.ts
@@ -19,6 +19,7 @@ import {
   Distribution,
   FunctionRuntime,
   IDistribution,
+  ResponseHeadersPolicy,
 } from "aws-cdk-lib/aws-cloudfront";
 import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
@@ -78,6 +79,7 @@ export class ApiGatewayArchitecture {
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         originRequestPolicy: props.originRequestPolicy,
         cachePolicy: props.cachePolicy,
+        responseHeadersPolicy: ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS_WITH_PREFLIGHT,
         functionAssociations: [
           {
             function: requestModifierFunction,

--- a/source/constructs/lib/back-end/s3-object-lambda-architecture.ts
+++ b/source/constructs/lib/back-end/s3-object-lambda-architecture.ts
@@ -20,6 +20,7 @@ import {
   Distribution,
   CfnOriginAccessControl,
   IDistribution,
+  ResponseHeadersPolicy,
 } from "aws-cdk-lib/aws-cloudfront";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Aspects, Aws, CfnCondition, Duration, Fn } from "aws-cdk-lib";
@@ -142,6 +143,7 @@ export class S3ObjectLambdaArchitecture {
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         originRequestPolicy: props.originRequestPolicy,
         cachePolicy: props.cachePolicy,
+        responseHeadersPolicy: ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS_WITH_PREFLIGHT,
         functionAssociations: [
           {
             function: responseModifierCloudFrontFunction,

--- a/source/constructs/test/__snapshots__/constructs.test.ts.snap
+++ b/source/constructs/test/__snapshots__/constructs.test.ts.snap
@@ -1059,6 +1059,7 @@ function processQueryParams(querystring) {
             "OriginRequestPolicyId": {
               "Ref": "BackEndOriginRequestPolicy771345D7",
             },
+            "ResponseHeadersPolicyId": "5cc3b908-e619-4b99-88e5-2cf7f45965bd",
             "TargetOriginId": "TestStackBackEndImageHandlerCloudFrontApiGatewayLambdaCloudFrontToApiGatewayCloudFrontDistributionOrigin1A053AEB7",
             "ViewerProtocolPolicy": "redirect-to-https",
           },
@@ -1753,6 +1754,7 @@ function processQueryParams(querystring) {
             "OriginRequestPolicyId": {
               "Ref": "BackEndOriginRequestPolicy771345D7",
             },
+            "ResponseHeadersPolicyId": "5cc3b908-e619-4b99-88e5-2cf7f45965bd",
             "TargetOriginId": "TestStackBackEndImageHandlerCloudFrontDistributionOrigin1781ABF9C",
             "ViewerProtocolPolicy": "redirect-to-https",
           },


### PR DESCRIPTION
## Summary

- Browsers that send a CORS preflight (OPTIONS) currently do not receive Access-Control-Allow-* headers on the preflight response because the image-handler CloudFront distribution has no ResponseHeadersPolicy attached.
- Attach the AWS-managed CORS-with-preflight policy (5cc3b908-e619-4b99-88e5-2cf7f45965bd) on the defaultBehavior of both the S3-Object-Lambda architecture and API-Gateway architecture paths so preflight and simple requests both get the full set of CORS headers.

Once merged, tag v8.0.5 will trigger the existing Deployment workflow to sync the rebuilt template to the dev and prod *-breakaway-image-solution-assets-us-west-2 S3 buckets. The downstream bump of local.imagecache.version to v8.0.5 in the devops repo is tracked separately.

## Test plan

- [x] Snapshot test updated (source/constructs/test/__snapshots__/constructs.test.ts.snap) with new ResponseHeadersPolicyId: 5cc3b908-... on both distributions
- [ ] After merge + tag v8.0.5: verify OPTIONS https://images.breakawaydata.com/<path> returns Access-Control-Allow-Origin, -Methods, -Headers, and Vary: Origin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Applies an AWS-managed `ResponseHeadersPolicy` to the default behavior of the image-handler CloudFront distributions, which changes HTTP response headers (CORS) for all viewer requests and could affect browser/client behavior and caching.
> 
> **Overview**
> Adds `responseHeadersPolicy: ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS_WITH_PREFLIGHT` to the default cache behavior for both back-end CloudFront distribution paths (API Gateway and S3 Object Lambda), enabling AWS-managed CORS headers on responses.
> 
> Updates the Jest snapshot to assert the generated `ResponseHeadersPolicyId` (`5cc3b908-e619-4b99-88e5-2cf7f45965bd`) is present on both distributions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c745b26c6f5cd7ad53ffe51298722038e13912c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->