### PR TITLE
feat: publish source/image-handler as @breakawaydata/dynamic-image-transformation

### DIFF
--- a/.github/workflows/release-image-handler.yaml
+++ b/.github/workflows/release-image-handler.yaml
@@ -22,23 +22,18 @@ jobs:
     permissions:
       contents: read
       packages: write
-    defaults:
-      run:
-        working-directory: source/image-handler
     steps:
       - name: Resolve ref
         id: resolve
         run: |
           if [[ -n "${{ inputs.tag }}" ]]; then
-            echo "ref=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
-            echo "version=${GITHUB_REF_NAME:-${{ inputs.tag }}}" >> /dev/null
-            version="${{ inputs.tag }}"
+            tag="${{ inputs.tag }}"
           else
-            echo "ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-            version="${{ github.ref_name }}"
+            tag="${{ github.ref_name }}"
           fi
+          echo "ref=$tag" >> "$GITHUB_OUTPUT"
           # Strip leading 'v' for npm semver
-          echo "version=${version#v}" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,15 +51,19 @@ jobs:
           cache-dependency-path: source/image-handler/package-lock.json
 
       - name: Pin package version to tag
+        working-directory: source/image-handler
         run: npm version "${{ steps.resolve.outputs.version }}" --no-git-tag-version --allow-same-version
 
       - name: Install
+        working-directory: source/image-handler
         run: npm ci
 
       - name: Build
+        working-directory: source/image-handler
         run: npm run build
 
       - name: Publish
+        working-directory: source/image-handler
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-image-handler.yaml
+++ b/.github/workflows/release-image-handler.yaml
@@ -1,0 +1,70 @@
+name: Release @breakawaydata/dynamic-image-transformation
+
+# Publishes source/image-handler as an npm package to GitHub Packages.
+# Triggers on the same vX.Y.Z tag push that drives the Lambda/S3 deployment,
+# so the library version always tracks the Lambda release. Also supports
+# manual workflow_dispatch for backfilling existing tags.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to publish (e.g. v8.0.5). Must already exist.'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    defaults:
+      run:
+        working-directory: source/image-handler
+    steps:
+      - name: Resolve ref
+        id: resolve
+        run: |
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            echo "ref=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "version=${GITHUB_REF_NAME:-${{ inputs.tag }}}" >> /dev/null
+            version="${{ inputs.tag }}"
+          else
+            echo "ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            version="${{ github.ref_name }}"
+          fi
+          # Strip leading 'v' for npm semver
+          echo "version=${version#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.resolve.outputs.ref }}
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@breakawaydata'
+          cache: 'npm'
+          cache-dependency-path: source/image-handler/package-lock.json
+
+      - name: Pin package version to tag
+        run: npm version "${{ steps.resolve.outputs.version }}" --no-git-tag-version --allow-same-version
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/source/image-handler/lib-entry.ts
+++ b/source/image-handler/lib-entry.ts
@@ -1,0 +1,17 @@
+// Library entry point for @breakawaydata/dynamic-image-transformation.
+// Exposes the Sharp pipeline + request parser as ordinary classes so non-Lambda
+// consumers (e.g. the local-dev image server in breakaway-monorepo) can reuse
+// the same code that the production Lambda runs.
+//
+// The Lambda handler itself lives in ./index.ts and is excluded from this
+// package build — it imports from ../solution-utils which belongs to the
+// deployment, not the library. Consumers wire their own S3/Rekognition/Secrets
+// clients and pass events directly to ImageRequest.setup().
+
+export { ImageHandler } from "./image-handler";
+export { ImageRequest, getAllowedSourceBuckets } from "./image-request";
+export { SecretProvider } from "./secret-provider";
+export { ThumborMapper } from "./thumbor-mapper";
+export { QueryParamMapper } from "./query-param-mapper";
+
+export * from "./lib";

--- a/source/image-handler/package-lock.json
+++ b/source/image-handler/package-lock.json
@@ -1,10 +1,12 @@
 {
-  "name": "image-handler",
+  "name": "@breakawaydata/dynamic-image-transformation",
+  "version": "0.0.0-placeholder",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "image-handler",
+      "name": "@breakawaydata/dynamic-image-transformation",
+      "version": "0.0.0-placeholder",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-rekognition": "^3.993.0",
@@ -1022,6 +1024,7 @@
       "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -3198,6 +3201,7 @@
       "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3505,6 +3509,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -4489,6 +4494,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -6012,6 +6018,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6085,6 +6092,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -1,15 +1,52 @@
 {
-  "name": "image-handler",
-  "private": true,
-  "description": "A Lambda function for performing on-demand image edits and manipulations.",
+  "name": "@breakawaydata/dynamic-image-transformation",
+  "description": "Reusable image transformation primitives (ImageHandler, ImageRequest, SecretProvider) extracted from the Dynamic Image Transformation for Amazon CloudFront solution. Publishes the Sharp-backed pipeline as a library so non-Lambda consumers (local dev servers, alternative deployments) can reuse the same code the Lambda runs.",
   "license": "Apache-2.0",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com/solutions"
   },
-  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/breakawaydata/dynamic-image-transformation-for-amazon-cloudfront.git",
+    "directory": "source/image-handler"
+  },
+  "version": "0.0.0-placeholder",
+  "main": "dist/lib-entry.js",
+  "types": "dist/lib-entry.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/lib-entry.d.ts",
+      "default": "./dist/lib-entry.js"
+    },
+    "./image-handler": {
+      "types": "./dist/image-handler.d.ts",
+      "default": "./dist/image-handler.js"
+    },
+    "./image-request": {
+      "types": "./dist/image-request.d.ts",
+      "default": "./dist/image-request.js"
+    },
+    "./secret-provider": {
+      "types": "./dist/secret-provider.d.ts",
+      "default": "./dist/secret-provider.js"
+    },
+    "./lib": {
+      "types": "./dist/lib/index.d.ts",
+      "default": "./dist/lib/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
   "scripts": {
     "clean": "rm -rf node_modules/ dist/ coverage/",
+    "build": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "npm run build",
     "pretest": "npm run clean && npm ci",
     "test": "jest --coverage --silent"
   },

--- a/source/image-handler/tsconfig.build.json
+++ b/source/image-handler/tsconfig.build.json
@@ -1,0 +1,26 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "types": ["node"]
+  },
+  "include": [
+    "lib-entry.ts",
+    "image-handler.ts",
+    "image-request.ts",
+    "secret-provider.ts",
+    "thumbor-mapper.ts",
+    "query-param-mapper.ts",
+    "lib/**/*.ts"
+  ],
+  "exclude": [
+    "index.ts",
+    "test/**",
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

Extract the Sharp-backed image pipeline from `source/image-handler/` as a publishable npm package (`@breakawaydata/dynamic-image-transformation`) on GitHub Packages. Non-Lambda consumers — starting with the local-dev image server in `breakaway-monorepo` ([BAE-4191](https://linear.app/breakaway-data/issue/BAE-4191)) — can now depend on the same code the production Lambda runs instead of vendoring it in.

The Lambda handler (`index.ts`) is intentionally excluded from the library build because it imports from `../solution-utils/` which belongs to the CDK deployment, not the library. Consumers wire their own S3 / Rekognition / Secrets Manager clients and call `ImageRequest.setup()` directly with an `ImageHandlerEvent`.

## Changes

- **`source/image-handler/package.json`**
  - Drop `"private": true`, rename to `@breakawaydata/dynamic-image-transformation`
  - Add `exports` / `main` / `types` / `files` pointing at `dist/`
  - `publishConfig.registry` → GitHub Packages, `access: restricted`
  - Add `build` (`tsc -p tsconfig.build.json`) and `prepublishOnly` scripts
  - Ship a placeholder version (`0.0.0-placeholder`) — the release workflow pins the real version from the git tag at publish time
- **`source/image-handler/lib-entry.ts`** (new) — public entry that re-exports `ImageHandler`, `ImageRequest`, `SecretProvider`, `ThumborMapper`, `QueryParamMapper`, `getAllowedSourceBuckets`, and `export * from "./lib"` (enums, types, interfaces, constants)
- **`source/image-handler/tsconfig.build.json`** (new) — library-only tsconfig with `declaration: true`. Excludes `index.ts` so Lambda plumbing does not leak into the published artifact
- **`.github/workflows/release-image-handler.yaml`** (new) — publishes to GitHub Packages on `vX.Y.Z` tag push, matching the existing `deployment.yaml` cadence so the library version always tracks the Lambda release. Also supports `workflow_dispatch` with a `tag` input so we can backfill existing tags (e.g. `v8.0.5`)

## Test plan

- [x] `npm install` + `npm run build` succeed locally — emits `dist/lib-entry.{js,d.ts}` + per-module files + `dist/lib/`
- [x] `npm pack --dry-run` shows only `dist/` (no source, no tests, no Lambda handler, no `solution-utils`) — 34 files, ~39 kB
- [x] Existing `npm test` still works (test script unchanged; `lib-entry.ts` is new so no existing tests hit it)
- [ ] Merge this PR, then run the workflow via `workflow_dispatch` with `tag: v8.0.5` to publish the current tag to GitHub Packages
- [ ] Subsequent `vX.Y.Z` tag pushes automatically publish to GitHub Packages alongside the existing S3 deployment

## Rollout

After merge:

1. Run `Release @breakawaydata/dynamic-image-transformation` workflow with `tag: v8.0.5` (the current release) to backfill the first published version.
2. Follow-up PR in `breakaway-monorepo` swaps the vendored copy in `apps/image-transform/src/vendor/` for a direct dependency on `@breakawaydata/dynamic-image-transformation@^8.0.5`.

No runtime behavior changes. The Lambda handler, deployment artifacts, and S3 push from `deployment.yaml` are untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to packaging/build configuration and a new GitHub Actions publish workflow, with no changes to the Lambda runtime logic.
> 
> **Overview**
> Publishes the reusable parts of `source/image-handler` as an npm library (`@breakawaydata/dynamic-image-transformation`) by adding a dedicated `lib-entry.ts` entrypoint and a library-only `tsconfig.build.json` that *excludes the Lambda handler* (`index.ts`) from the build.
> 
> Updates `package.json`/`package-lock.json` to be publishable (scoped name, `dist/`-based `main`/`types`/`exports`, `files`, GitHub Packages `publishConfig`, and a `build`/`prepublishOnly` pipeline).
> 
> Adds a new GitHub Actions workflow (`release-image-handler.yaml`) that, on `vX.Y.Z` tags (or manual `workflow_dispatch`), pins the package version to the tag and runs `npm ci`/`npm run build`/`npm publish` to GitHub Packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8e6ebe8ded33e502a592dab6ab50b49bc9bed95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->