### PR TITLE
fix(frontend): enforce HTTPS-only on demo/admin UI S3 buckets

### DIFF
--- a/source/constructs/lib/front-end/front-end-construct.ts
+++ b/source/constructs/lib/front-end/front-end-construct.ts
@@ -26,7 +26,9 @@ export class FrontEndConstruct extends Construct {
     super(scope, id);
 
     const cloudFrontToS3 = new CloudFrontToS3(this, "DistributionToS3", {
-      bucketProps: { serverAccessLogsBucket: undefined },
+      // enforceSSL adds a bucket policy that denies non-HTTPS (aws:SecureTransport=false)
+      // access, satisfying the "S3 buckets allow only HTTPS traffic" security control.
+      bucketProps: { serverAccessLogsBucket: undefined, enforceSSL: true },
       cloudFrontDistributionProps: {
         comment: "Demo UI Distribution for Dynamic Image Transformation for Amazon CloudFront",
         enableLogging: true,

--- a/source/constructs/lib/v8/constructs/frontend/ui-construct.ts
+++ b/source/constructs/lib/v8/constructs/frontend/ui-construct.ts
@@ -15,7 +15,9 @@ export class WebDistributionConstruct extends Construct {
     super(scope, id);
 
     const webConstruct: CloudFrontToS3 = new CloudFrontToS3(this, "AdminUIDistributionToS3", {
-      bucketProps: { serverAccessLogsBucket: undefined },
+      // enforceSSL adds a bucket policy that denies non-HTTPS (aws:SecureTransport=false)
+      // access, satisfying the "S3 buckets allow only HTTPS traffic" security control.
+      bucketProps: { serverAccessLogsBucket: undefined, enforceSSL: true },
       cloudFrontDistributionProps: {
         comment: "Admin UI Distribution for Dynamic Image Transformation for Amazon CloudFront",
         enableLogging: true,


### PR DESCRIPTION
## What & why

The two front-end `CloudFrontToS3` buckets in this solution are created **without a bucket policy that denies non-HTTPS access**, so they fail the **"S3 buckets allow only HTTPS traffic"** control (flagged by Vanta in our AWS accounts).

This sets `enforceSSL: true` on their `bucketProps`, so CDK generates the standard `aws:SecureTransport=false` deny statement. This matches the pattern already used elsewhere in the repo (`v8/stacks/image-processing-stack.ts`).

**Changes (2 lines):**
- `source/constructs/lib/front-end/front-end-construct.ts` — `DistributionToS3` (demo UI) bucket → `enforceSSL: true`
- `source/constructs/lib/v8/constructs/frontend/ui-construct.ts` — `AdminUIDistributionToS3` bucket → `enforceSSL: true`

## Snapshot tests

I did **not** commit regenerated snapshots. The construct snapshot test does a full synth that bundles the Lambda assets, so regenerating locally bakes in environment-specific asset hashes and produces noisy diffs. Please run `npm test -- -u` in CI / a standard build environment to refresh `test/__snapshots__/constructs.test.ts.snap`.

## ⚠️ REQUIRED follow-up: bucket cleanup (this PR alone does NOT clear the finding)

`enforceSSL` only affects buckets **at creation time**. It does not retroactively add a policy to buckets that already exist. To actually clear the Vanta finding, the following is required **after** this change is released and the solution redeployed:

1. **Rebuild + republish** the solution assets/template from this fork, and **bump the pinned version** where the stack is deployed (in `breakaway/devops`, `ba-compete-imagecache.tf` currently pins `v8.0.5`).
2. **Delete the existing orphaned front-end buckets** in the Dev account (`breakawaydata-dev` / 730335393542). The demo UI is currently deployed with `DeployDemoUIParameter = "No"` and **prod has none of these buckets**, so these are leftovers from an earlier deploy and are safe to remove:
   - `dev-ba-compete-image-cach-frontenddistributiontos3-illu9ozy2ko9` (holds `index.html` / `demo-ui-config.js`)
   - `dynamic-image-transformat-frontenddistributiontos3-1ttevtwm1pis` (empty)
   - `dynamic-image-transformat-frontenddistributiontos3-mngh8rtebbuo` (empty)

   Verify each is unreferenced/empty, then delete. Newly created front-end buckets (if the demo UI is ever re-enabled) will inherit the HTTPS-only policy from this change.

Related: the `breakaway/devops` PR that fixes the other S3 buckets for the same Vanta control (breakawaydata/devops#467) originally band-aided these image-cache buckets from the Terraform side; that band-aid was reverted in favor of this source fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
